### PR TITLE
Remove confusion metrics as primary metric choices

### DIFF
--- a/recipe.yaml
+++ b/recipe.yaml
@@ -23,8 +23,7 @@ positive_class: ""
 # FIXME::REQUIRED: Sets the primary metric to use to evaluate model performance. This primary
 #                  metric is used to select best performing models in MLflow UI as well as in
 #                  train and evaluation step.
-#                  Built-in metrics are: true_negatives, false_positives, false_negatives,
-#                  true_positives, recall_score, precision_score, f1_score, accuracy_score.
+#                  Built-in primary metrics are: recall_score, precision_score, f1_score, accuracy_score.
 primary_metric: ""
 steps:
   # Specifies the dataset to use for model development


### PR DESCRIPTION
Signed-off-by: Prithvi Kannan <prithvi.kannan@databricks.com>

The primary metric should not include the confusion matrix metrics (true_negatives, false_positives, false_negatives, true_positives)