### PR TITLE
Specify custom file format types in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ One may specify multiple data locations by a list of locations as long as they h
   ```
 - `using`: string. Required.  
 One of `parquet`, `spark_sql` and `delta`, or the custom file format specified by the
-loaer function in `steps/ingest.py` (ex. `csv`).  
+loader function in `steps/ingest.py` (ex. `csv`).  
 
 
 - `loader_method`: string. Optional.  

--- a/README.md
+++ b/README.md
@@ -142,7 +142,8 @@ One may specify multiple data locations by a list of locations as long as they h
   location: ["./data/sample.parquet", "https://d37ci6vzurychx.cloudfront.net/trip-data/yellow_tripdata_2022-01.parquet"]
   ```
 - `using`: string. Required.  
-One of `parquet`, `spark_sql` and `delta`.  
+One of `parquet`, `spark_sql` and `delta`, or the custom file format specified by the
+loaer function in `steps/ingest.py` (ex. `csv`).  
 
 
 - `loader_method`: string. Optional.  


### PR DESCRIPTION
Signed-off-by: Apurva Koti <apurva.koti@databricks.com>

Specify that custom file formats are allowed in the `using` parameter.